### PR TITLE
Fixed scale on vec2 and vec3

### DIFF
--- a/src/vec2.ts
+++ b/src/vec2.ts
@@ -126,8 +126,8 @@ export default class vec2 {
     scale(value: number, dest?: vec2): vec2 {
         if (!dest) { dest = this }
 
-        dest.x *= value
-        dest.y *= value
+        dest.x = this.x * value
+        dest.y = this.y * value
 
         return dest
     }

--- a/src/vec3.ts
+++ b/src/vec3.ts
@@ -163,9 +163,9 @@ export default class vec3 {
     scale(value: number, dest?: vec3): vec3 {
         if (!dest) { dest = this }
 
-        dest.x *= value
-        dest.y *= value
-        dest.z *= value
+        dest.x = this.x * value
+        dest.y = this.y * value
+        dest.z = this.z * value
 
         return dest
     }


### PR DESCRIPTION
They both ignored the value of `this` when a dest vector was provided